### PR TITLE
Configure Next.js images to be unoptimized in next.config.ts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,8 +3,8 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
   
-  env: {
-    NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+  images: {
+    unoptimized: true
   }
 };
 


### PR DESCRIPTION
Replace the env configuration with the images.unoptimized option set to true to disable Next.js image optimization, likely for compatibility with custom image handling or deployment environments.