### PR TITLE
Update image config to allow domains for localhost and Vercel app

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,7 @@ const nextConfig: NextConfig = {
   /* config options here */
   
   images: {
-    unoptimized: true
+    domains: ["localhost", "waifu-metaverse-web.vercel.app"],
   }
 };
 


### PR DESCRIPTION
Replace unoptimized image setting with allowed domains for "localhost" and "waifu-metaverse-web.vercel.app" to enable optimized image loading from these sources.