### PR TITLE
Allow images from public.blob.vercel-storage.com in next config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,9 @@ const nextConfig: NextConfig = {
   
   images: {
     domains: ["localhost", "waifu-metaverse-web.vercel.app"],
+    remotePatterns: [
+      { hostname: "public.blob.vercel-storage.com" },
+    ]
   }
 };
 


### PR DESCRIPTION
Add public.blob.vercel-storage.com to remotePatterns in the Next.js image configuration to enable loading images from this external storage domain. This supports serving images hosted on Vercel Blob Storage.