### PR TITLE
Update image domains to use specific Vercel storage hostname

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,9 +4,9 @@ const nextConfig: NextConfig = {
   /* config options here */
   
   images: {
-    domains: ["localhost", "waifu-metaverse-web.vercel.app"],
+    domains: ["localhost", "9fDeOMRF8RcfTt1w.public.blob.vercel-storage.com"],
     remotePatterns: [
-      { hostname: "public.blob.vercel-storage.com" },
+      { hostname: "9fDeOMRF8RcfTt1w.public.blob.vercel-storage.com" },
     ]
   }
 };


### PR DESCRIPTION
Replace generic and previous domains with "9fDeOMRF8RcfTt1w.public.blob.vercel-storage.com" in image configuration to restrict allowed sources and improve security.