### PR TITLE
Fix typo in next.config.ts: rename 'image' to 'images' in config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
-  image: {
+  images: {
     unoptimized: true,
   }
 };


### PR DESCRIPTION
Correct the property name from 'image' to 'images' to properly configure Next.js image optimization settings.